### PR TITLE
[UPD] l10n_nl_rgs: Changes for accounts and added reconcile models

### DIFF
--- a/l10n_nl_rgs/__manifest__.py
+++ b/l10n_nl_rgs/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Netherlands - RGS Accounting (3.5.2)",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "category": "Accounting/Localizations/Account Charts",
     "author": "Onestein",
     "website": "https://www.onestein.nl",
@@ -20,6 +20,7 @@
         "data/account_fiscal_position_template.xml",
         "data/account_fiscal_position_tax_template.xml",
         "data/account_fiscal_position_account_template.xml",
+        "data/account_reconcile_model_template.xml",
         "data/account_chart_template_data.xml",
         "views/res_config_settings_views.xml",
         "views/account_account_views.xml",

--- a/l10n_nl_rgs/data/account.account.template.csv
+++ b/l10n_nl_rgs/data/account.account.template.csv
@@ -382,7 +382,7 @@
 "1103102","Rekening-courant groepsmaatschappij 3","Rekening-courant groepsmaatschappij 3","1103102","BVorVogVr3","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103099","0","G.B.C",1
 "1103103","Rekening-courant groepsmaatschappij 4","Rekening-courant groepsmaatschappij 4","1103103","BVorVogVr4","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103099","0","G.B.D",1
 "1103104","Rekening-courant groepsmaatschappij 5","Rekening-courant groepsmaatschappij 5","1103104","BVorVogVr5","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103099","0","G.B.E",1
-"1103105","Vordering / lening Daeb","Vordering / lening groepsmaatschappij 1","1103105","BVorVogVg1","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103099","0","G.B.P",0
+"1103105","Vordering / lening Daeb","Vordering / lening groepsmaatschappij 1","1103105","BVorVogVg1","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103099","0","G.B.P",1
 "1103106","Rekening-courant DAEB","Rekening-courant DAEB","1103106","BVorVogDae","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103099","0","G.B.Q",1
 "1103107","Rekening-courant Niet-DAEB","Rekening-courant Niet-DAEB","1103107","BVorVogNda","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103099","0","G.B.R",1
 "1103110","Rekening-courant overige verbonden maatschappij 1","Rekening-courant overige verbonden maatschappij 1","1103110","BVorVovVr1","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103109","0","G.C.A",0
@@ -418,7 +418,7 @@
 "1103340","Vorderingen op lid D van de coöperatie","Vorderingen op lid D van de coöperatie","1103340","BVorVlcLi4","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103300","0","G.E.D",1
 "1103350","Vorderingen op lid E van de coöperatie","Vorderingen op lid E van de coöperatie","1103350","BVorVlcLi5","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103300","0","G.E.E",1
 "1103390","Interne lening (kortlopend)","Interne lening (kortlopend)","1103390","BVorOvrIln","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103000","0","G.K.V",1
-"1103400","Margin-call deposito","Margin-call deposito","1103400","BVorOvrMcd","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103000","0","G.K.W",1
+"1103007","Margin-call deposito","Margin-call deposito","1103007","BVorOvrMcd","asset_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1103000","0","G.K.W",1
 "1104010","Vooruitbetaalde facturen","Vooruitbetaalde facturen","1104010","BVorOvaVof","liability_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1104000","1","G.L.A",0
 "1104020","Vooruitverzonden op bestellingen","Vooruitverzonden op bestellingen","1104020","BVorOvaVbs","liability_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1104000","1","G.L.B",0
 "1104030","Nog te factureren of nog te verzenden facturen","Nog te factureren of nog te verzenden facturen","1104030","BVorOvaNtf","liability_current","l10n_nl_rgs.l10nnl_rgs_chart_template","l10n_nl_rgs.account_tag_1104000","1","G.L.C",0

--- a/l10n_nl_rgs/data/account_reconcile_model_template.xml
+++ b/l10n_nl_rgs/data/account_reconcile_model_template.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="prive_opname_template" model="account.reconcile.model.template">
+        <field name="chart_template_id" ref="l10nnl_rgs_chart_template"/>
+        <field name="name">Privé opname</field>
+        <field name="rule_type">writeoff_button</field>
+    </record>
+    <record id="prive_opname_line_template" model="account.reconcile.model.line.template">
+        <field name="model_id" ref="prive_opname_template"/>
+        <field name="account_id" ref="0509040"/>
+        <field name="amount_string">100</field>
+    </record>
+    <record id="prive_storting_template" model="account.reconcile.model.template">
+        <field name="chart_template_id" ref="l10nnl_rgs_chart_template"/>
+        <field name="name">Privé storting</field>
+        <field name="rule_type">writeoff_button</field>
+    </record>
+    <record id="prive_storting_line_template" model="account.reconcile.model.line.template">
+        <field name="model_id" ref="prive_storting_template"/>
+        <field name="account_id" ref="0509030"/>
+        <field name="amount_string">100</field>
+    </record>
+    <record id="kruisposten_template" model="account.reconcile.model.template">
+        <field name="chart_template_id" ref="l10nnl_rgs_chart_template"/>
+        <field name="name">Kruisposten</field>
+        <field name="rule_type">writeoff_button</field>
+    </record>
+    <record id="kruisposten_line_template" model="account.reconcile.model.line.template">
+        <field name="model_id" ref="kruisposten_template"/>
+        <field name="account_id" ref="1003010"/>
+        <field name="amount_string">100</field>
+    </record>
+    <record id="bankkosten_template" model="account.reconcile.model.template">
+        <field name="chart_template_id" ref="l10nnl_rgs_chart_template"/>
+        <field name="name">Bankkosten</field>
+        <field name="rule_type">writeoff_button</field>
+    </record>
+    <record id="bankkosten_line_template" model="account.reconcile.model.line.template">
+        <field name="model_id" ref="bankkosten_template"/>
+        <field name="account_id" ref="4210040"/>
+        <field name="amount_string">100</field>
+    </record>
+    <record id="verzekeringen_template" model="account.reconcile.model.template">
+        <field name="chart_template_id" ref="l10nnl_rgs_chart_template"/>
+        <field name="name">Verzekeringen</field>
+        <field name="rule_type">writeoff_button</field>
+    </record>
+    <record id="verzekeringen_line_template" model="account.reconcile.model.line.template">
+        <field name="model_id" ref="verzekeringen_template"/>
+        <field name="account_id" ref="4208020"/>
+        <field name="amount_string">100</field>
+    </record>
+    <record id="spaarrekening_template" model="account.reconcile.model.template">
+        <field name="chart_template_id" ref="l10nnl_rgs_chart_template"/>
+        <field name="name">Spaarrekening</field>
+        <field name="rule_type">writeoff_button</field>
+    </record>
+    <record id="spaarrekening_line_template" model="account.reconcile.model.line.template">
+        <field name="model_id" ref="spaarrekening_template"/>
+        <field name="account_id" ref="1002070"/>
+        <field name="amount_string">100</field>
+    </record>
+
+</odoo>

--- a/l10n_nl_rgs/migrations/16.0.1.1.0/pre-migrate.py
+++ b/l10n_nl_rgs/migrations/16.0.1.1.0/pre-migrate.py
@@ -1,0 +1,34 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def _fix_accounts(env):
+    rgs_template = env.ref("l10n_nl_rgs.l10nnl_rgs_chart_template")
+    for company in (
+        env["res.company"]
+        .with_context(active_test=False)
+        .search([("chart_template_id", "=", rgs_template.id)])
+    ):
+        account = env["account.account"].search(
+            [("code", "=", 1103400), ("company_id", "=", company.id)]
+        )
+        if account:
+            account.write({"code": 1103007})
+        account = env["account.account"].search(
+            [("code", "=", 1103105), ("company_id", "=", company.id)]
+        )
+        if account:
+            account.write({"deprecated": True})
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    cr.execute(
+        """UPDATE ir_model_data
+           SET name=%s
+           WHERE module='l10n_nl_rgs' AND name=%s
+        """,
+        ("1103007", "1103400"),
+    )
+    _fix_accounts(env)

--- a/l10n_nl_rgs/models/account_group.py
+++ b/l10n_nl_rgs/models/account_group.py
@@ -7,7 +7,7 @@ from odoo import fields, models
 
 class AccountGroup(models.Model):
     _inherit = "account.group"
-    _order = "sort_code, code, code_prefix_start"
+    _order = "code_prefix_start,sort_code"
 
     # FIXME: This should be English with Dutch translation
     referentiecode = fields.Char()


### PR DESCRIPTION
This includes following changes:
1.Account Margin call does not have Group. The Group should be G.K (achieved this by changing account code)
2.Account 1103105 should be set to inactive (deprecated)
3.Changes for account group sorting (used code_prefix_start,sort_code as the order).
4.Added Default reconciliation models with RGS chart of accounts