### PR TITLE
[UPD] website_membership_group: Added snippet options to customize the membership group page

### DIFF
--- a/website_membership_group/__manifest__.py
+++ b/website_membership_group/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Website Membership Group",
     "category": "Membership",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.3",
     "author": "Onestein",
     "license": "AGPL-3",
     "website": "https://www.onestein.nl",
@@ -15,5 +15,15 @@
     "data": [
         "views/membership_group_view.xml",
         "templates/website.xml",
+        "views/snippets/snippet_options.xml",
     ],
+    "assets": {
+        "web.assets_frontend": [
+            "website_membership_group/static/src/scss/membership_group.scss",
+            "website_membership_group/static/src/js/membership_group_frontend.esm.js",
+        ],
+        "website.assets_wysiwyg": [
+            "website_membership_group/static/src/js/membership_group_options.esm.js",
+        ],
+    },
 }

--- a/website_membership_group/models/membership_group.py
+++ b/website_membership_group/models/membership_group.py
@@ -7,7 +7,7 @@ from odoo.tools.translate import html_translate
 
 class MembershipGroup(models.Model):
     _name = "membership.group"
-    _inherit = ["membership.group", "website.published.mixin"]
+    _inherit = ["membership.group", "website.published.mixin", "website.seo.metadata"]
 
     website_top = fields.Html(strip_style=True, translate=html_translate)
     website_bottom = fields.Html(strip_style=True, translate=html_translate)
@@ -15,6 +15,22 @@ class MembershipGroup(models.Model):
     icon = fields.Image()
     page_id = fields.Many2one(comodel_name="website.page")
     website_url = fields.Char(compute="_compute_website_url", store=True)
+    website_snippet_wrap_classes = fields.Char(
+        string="Wrap Classes",
+        default="mg_wrap mg_show_image mg_show_top mg_show_bottom mg_show_committee mg_show_team",
+        help="Classes for the #wrap element (visibility options)",
+    )
+    website_snippet_members_classes = fields.Char(
+        string="Members Row Classes",
+        default="mg_layout_grid mg_show_committee_desc mg_show_team_desc",
+        help="Classes for the #mg_members_row element (layout and description options)",
+    )
+    website_committee_col_classes = fields.Char(
+        string="Committee Column Classes", default="col-lg-4"
+    )
+    website_team_col_classes = fields.Char(
+        string="Team Column Classes", default="col-lg-8"
+    )
 
     @api.depends("page_id", "page_id.is_published")
     def _compute_website_url(self):

--- a/website_membership_group/static/src/js/membership_group_frontend.esm.js
+++ b/website_membership_group/static/src/js/membership_group_frontend.esm.js
@@ -1,0 +1,38 @@
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+publicWidget.registry.MembershipGroupCollapsible = publicWidget.Widget.extend({
+    selector: '#mg_members_row',
+
+    start: function () {
+        this.setupCollapsibleButtons();
+        return this._super.apply(this, arguments);
+    },
+
+    setupCollapsibleButtons: function () {
+        const buttons = this.el.querySelectorAll('.mg_collapse_btn');
+        buttons.forEach(button => {
+            button.onclick = (e) => {
+                e.preventDefault();
+                this.toggleDescription(button);
+            };
+        });
+    },
+
+    toggleDescription: function (button) {
+        const descriptionId = button.getAttribute('aria-controls');
+        // eslint-disable-next-line no-undef
+        const description = document.getElementById(descriptionId);
+
+        if (!description) return;
+
+        const isExpanded = button.getAttribute('aria-expanded') === 'true';
+
+        if (isExpanded) {
+            description.classList.add('d-none');
+            button.setAttribute('aria-expanded', 'false');
+        } else {
+            description.classList.remove('d-none');
+            button.setAttribute('aria-expanded', 'true');
+        }
+    },
+});

--- a/website_membership_group/static/src/js/membership_group_options.esm.js
+++ b/website_membership_group/static/src/js/membership_group_options.esm.js
@@ -1,0 +1,127 @@
+import options from "@web_editor/js/editor/snippets.options";
+import { rpc } from "@web/core/network/rpc";
+/**
+ * Helper to filter for module-specific option classes.
+ * Excludes base structural classes to prevent duplication in templates.
+ */
+const filterMgClasses = (classList, excludeClass) => {
+    return classList.split(/\s+/)
+        .filter(cls => cls.startsWith('mg_') && cls !== excludeClass)
+        .join(' ');
+};
+options.registry.MembershipGroupPage = options.Class.extend({
+    /**
+     * @override
+     */
+    // eslint-disable-next-line no-unused-vars
+    selectClass: function (previewMode, widgetValue, params) {
+        this._super(...arguments);
+        // Only save to database on actual click (not during hover preview)
+        if (!previewMode) {
+            this._saveToDatabase();
+        }
+    },
+
+    /**
+     * Save the current class list to the database
+     */
+    _saveToDatabase: function () {
+        const id = parseInt(this.$target[0].dataset.oeId,10);
+        // Filter to keep only option classes, excluding 'mg_wrap'
+        const classes = filterMgClasses(this.$target[0].className, 'mg_wrap');
+        if (this.lastSavedClasses !== classes) {
+            this.lastSavedClasses = classes;
+            if (id && classes) {
+                return rpc('/web/dataset/call_kw', {
+                    model: "membership.group",
+                    method: 'write',
+                    args: [[id], {'website_snippet_wrap_classes': classes}],
+                    kwargs: {},
+                });
+            }
+        }
+    },
+});
+
+options.registry.MemberLayoutOpts = options.Class.extend({
+    /**
+     * @override
+     * Triggered for Layout and Description toggles.
+     */
+     // eslint-disable-next-line no-unused-vars
+    selectClass: function (previewMode, value, $li) {
+        this._super(...arguments);
+        if (!previewMode) {
+            this._saveToDatabase();
+        }
+    },
+
+    _saveToDatabase: function () {
+        const id = parseInt(this.$target[0].dataset.oeId,10);
+        // Filter to keep only option classes, excluding 'mg_members_row'
+        const classes = filterMgClasses(this.$target[0].className, 'mg_members_row');
+
+        if (this.lastSavedClasses !== classes) {
+            this.lastSavedClasses = classes;
+            if (id && classes) {
+                return rpc('/web/dataset/call_kw', {
+                    model: "membership.group",
+                    method: 'write',
+                    args: [[id], {'website_snippet_members_classes': classes}],
+                    kwargs: {},
+                });
+            }
+        }
+    },
+});
+
+options.registry.MemberColOpts = options.Class.extend({
+    start: function () {
+        const self = this;
+        this._super(...arguments);
+
+        this.observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.attributeName === "class") {
+                    self._saveToDatabase();
+                }
+            });
+        });
+
+        this.observer.observe(this.$target[0], {
+            attributes: true,
+            attributeFilter: ["class"],
+        });
+    },
+
+    destroy: function () {
+        if (this.observer) {
+            this.observer.disconnect();
+        }
+        this._super(...arguments);
+    },
+
+    _saveToDatabase: function () {
+        const $row = this.$target.closest('#mg_members_row');
+        const id = parseInt($row[0]?.dataset.oeId, 10);
+        const classes = this.$target[0].className.split(/\s+/)
+            .filter(cls => cls.startsWith('mg_') || cls.startsWith('col-'))
+            .join(' ');
+
+        const field = this.$target.hasClass('mg_committee_col')
+            ? 'website_committee_col_classes'
+            : 'website_team_col_classes';
+
+        if (id && field && classes) {
+            if (this.lastSavedColClasses !== classes) {
+                this.lastSavedColClasses = classes;
+                return rpc('/web/dataset/call_kw', {
+                    model: "membership.group",
+                    method: 'write',
+                    args: [[id], {[field]: classes}],
+                    kwargs: {},
+                });
+            }
+        }
+    },
+});

--- a/website_membership_group/static/src/scss/membership_group.scss
+++ b/website_membership_group/static/src/scss/membership_group.scss
@@ -1,0 +1,183 @@
+/* =======================================================================
+   VISIBILITY TOGGLES (LAYOUT)
+   Controlled via classes applied to the #wrap element
+   ======================================================================= */
+.mg_wrap {
+    // Default: Hide all optional sections
+    .mg_image_col,
+    .mg_top_block,
+    .mg_bottom_block,
+    .mg_committee_col,
+    .mg_team_col {
+        display: none;
+    }
+
+    // Toggle display based on snippet option classes
+    &.mg_show_image .mg_image_col      { display: block; }
+    &.mg_show_top .mg_top_block        { display: block; }
+    &.mg_show_bottom .mg_bottom_block  { display: block; }
+    &.mg_show_committee .mg_committee_col { display: block; }
+    &.mg_show_team .mg_team_col        { display: block; }
+}
+
+/* =======================================================================
+   MEMBER DESCRIPTION VISIBILITY & COLLAPSIBLE SYSTEM
+   Tied to Committee Desc / Team Desc snippet options
+   ======================================================================= */
+
+/* Default: Hide descriptions and buttons for both sections */
+.mg_member_description,
+.mg_collapse_btn {
+    display: none !important;
+}
+
+// Show descriptions if the respective section toggle is ON
+.mg_show_team_desc .mg_team_col .mg_member_description,
+.mg_show_committee_desc .mg_committee_col .mg_member_description {
+    display: block !important;
+}
+
+/* Hide descriptions if collapsible is active and closed */
+#mg_members_row.mg_collapse_desc .mg_member_description.d-none {
+    display: none !important;
+}
+
+/* Animation for expanding descriptions */
+#mg_members_row.mg_collapse_desc:not(.mg_layout_grid) .mg_member_description:not(.d-none) {
+    display: block !important;
+    animation: slideDown 0.3s ease-in-out;
+}
+
+/* Show buttons ONLY if BOTH Collapsible AND the respective Section Toggle are ON */
+#mg_members_row:not(.mg_layout_grid).mg_collapse_desc.mg_show_committee_desc .mg_collapse_btn,
+#mg_members_row:not(.mg_layout_grid).mg_collapse_desc.mg_show_team_desc .mg_collapse_btn {
+    display: inline-flex !important;
+    padding: 0.25rem 0.5rem;
+    color: #6c757d;
+    font-size: 0.875rem;
+    transition: transform 0.3s ease-in-out, color 0.2s ease-in-out;
+}
+
+#mg_members_row.mg_collapse_desc .mg_collapse_btn:hover {
+    color: $primary;
+}
+
+#mg_members_row.mg_collapse_desc .mg_collapse_btn[aria-expanded="true"] {
+    transform: rotate(180deg);
+}
+
+#mg_members_row.mg_collapse_desc .mg_collapse_btn[aria-expanded="true"] i {
+    color: $primary;
+}
+
+@keyframes slideDown {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* =======================================================================
+   MEMBER LAYOUT VARIANTS
+   ======================================================================= */
+
+/* --- GRID LAYOUT --- */
+#mg_members_row.mg_layout_grid {
+    .mg_member_list {
+        gap: 0;
+    }
+
+    /* 1 Column for Committee Section in Grid */
+    .mg_committee_col .mg_member_item {
+        flex: 0 0 100%;
+    }
+
+    /* 2 Columns for Team Section in Grid */
+    .mg_team_col .mg_member_item {
+        flex: 0 0 50%;
+    }
+
+    /* Force hide description and collapse buttons in Grid Layout */
+    .mg_member_description,
+    .mg_collapse_btn {
+        display: none !important;
+    }
+}
+
+/* --- CARDS LAYOUT --- */
+#mg_members_row.mg_layout_cards {
+    .mg_member_list {
+        gap: 0.75rem;
+        padding: 0.75rem;
+    }
+
+    .mg_member_item {
+        flex: 1 1 100% !important;
+        width: 100%;
+        min-width: 0;
+        border: 1px solid $border-color !important;
+        border-radius: $border-radius !important;
+        background: #fff;
+        box-shadow: $box-shadow-sm;
+        padding: 1rem !important;
+        transition: box-shadow 0.15s ease-in-out;
+
+        &:hover {
+            box-shadow: $box-shadow;
+        }
+    }
+
+    .mg_member_name {
+        text-align: left;
+    }
+}
+
+/* --- AVATARS LAYOUT --- */
+#mg_members_row.mg_layout_avatars {
+    .mg_member_list {
+        gap: 1rem;
+        padding: 1rem;
+    }
+
+    .mg_member_item {
+        flex: 1 1 100% !important;
+        width: 100%;
+        min-width: 0;
+        border: none !important;
+        border-radius: 0 !important;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        padding: 0.5rem 0.25rem !important;
+        background: transparent;
+    }
+
+    .mg_member_name {
+        font-size: 0.8125rem;
+        text-align: center;
+    }
+
+    .mg_collapse_btn {
+        margin: 0 auto;
+        display: block;
+        text-align: center;
+    }
+}
+
+/* =======================================================================
+   STYLING & THEMING
+   ======================================================================= */
+.mg_divider {
+    border-color: $primary;
+}
+
+/* =======================================================================
+   RESPONSIVE BREAKPOINTS
+   ======================================================================= */
+@include media-breakpoint-down(sm) {
+    #mg_members_row.mg_layout_avatars .mg_member_item { flex: 1 1 calc(50% - 0.5rem); }
+}
+
+@include media-breakpoint-down(md) {
+    #mg_members_row.mg_layout_cards .mg_member_item { flex: 1 1 100%; }
+    #mg_members_row.mg_layout_avatars .mg_member_item { flex: 1 1 calc(50% - 1rem); }
+}

--- a/website_membership_group/templates/website.xml
+++ b/website_membership_group/templates/website.xml
@@ -1,99 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <odoo>
-
     <template id="membership_group_page">
         <t t-call="website.layout">
             <t t-set="additional_title" t-value="title"/>
-            <div id="wrap">
+            <div id="wrap"
+                 t-att-data-oe-id="membership_group.id"
+                 t-attf-class="mg_wrap o_editable {{membership_group.website_snippet_wrap_classes or 'mg_show_image mg_show_top mg_show_bottom mg_show_committee mg_show_team'}}">
                 <div class="oe_structure" id="oe_structure_website_group_1"/>
-                <div class="container" name="membership_page">
-                    <div class="row" name="description_row">
-                        <h3 class="col-lg-12 text-center" id="membership_group_name"
-                            t-field="membership_group.name"/>
-                        <div class="col-lg-4">
-                            <div t-field="membership_group.image"
-                                 t-options='{"widget": "image", "class": "d-block mx-auto mb16"}'/>
+                <section class="mg_header_section pt-5 pb-4">
+                    <div class="container" name="membership_page">
+                        <div class="row" name="description_row">
+                            <div class="col-12 text-center mb-4">
+                                <h2 class="fw-bold text-primary" t-field="membership_group.name"/>
+                                <hr class="w-25 mx-auto mt-2 mb-0 mg_divider opacity-50"/>
+                            </div>
                         </div>
-                        <div class="col-lg-8 mt32">
-                            <t t-if="membership_group">
-                                <div t-field="membership_group.website_top"/>
-                                <div t-field="membership_group.website_bottom"/>
-                            </t>
+                        <div class="row align-items-start g-4">
+                            <div class="col-lg-4 text-center mg_image_col">
+                                <div t-field="membership_group.image"
+                                     t-options='{"widget": "image", "class": "img-fluid rounded shadow"}'/>
+                            </div>
+                            <div class="col-lg-8 mg_desc_col">
+                                <div class="mg_top_block" t-field="membership_group.website_top"/>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="container mt16">
-                    <div class="row o_web_membership_group_members_list_container">
-                        <t t-set="current_members"
-                           t-value="membership_group.membership_group_member_ids.filtered(lambda m:m.state=='current')"/>
-                        <div class="col-lg-4 col-md-4 mb48">
-                            <div class="col-lg-12">
-                                <div class="card card-body bg-light">
-                                    <div class="o_web_membership_group_committee_member">
-                                        <h4>Committee Members:</h4>
-                                        <t t-set="committee_members"
-                                           t-value="current_members.filtered(lambda m:m.type == 'committee').mapped('partner_id')"
-                                        />
-                                        <t t-if="committee_members">
-                                            <t t-call="website_membership_group.membership_group_member">
-                                                <t t-set="members"
-                                                   t-value="committee_members"/>
+                </section>
+
+                <section class="mg_members_section py-5">
+                    <div class="container">
+                        <div t-attf-class="row g-4 mg_members_row {{membership_group.website_snippet_members_classes or 'mg_layout_grid mg_show_committee_desc mg_show_team_desc'}}"
+                             id="mg_members_row"
+                             t-att-data-oe-id="membership_group.id"
+                        >
+                            <t t-set="current_members"
+                                               t-value="membership_group.membership_group_member_ids.filtered(lambda m: m.state == 'current')"/>
+                            <div t-attf-class="mg_committee_col {{membership_group.website_committee_col_classes or 'col-lg-4'}}">
+                                <div class="card h-100 shadow-sm border-0">
+                                    <div class="card-header border-0 py-3 bg-primary text-white"
+                                         data-name="Committee Header">
+                                        <h5 class="mb-0 fw-semibold">Committee Members</h5>
+                                    </div>
+                                    <div class="card-body p-0">
+                                        <div>
+                                            <t t-set="committee_members"
+                                               t-value="current_members.filtered(lambda m: m.type == 'committee').mapped('partner_id')"/>
+                                            <t t-call="website_membership_group.membership_group_member_list">
+                                                <t t-set="members" t-value="committee_members"/>
                                             </t>
-                                        </t>
-                                        <h5 t-else="">No Committee Members found.</h5>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div t-attf-class="mg_team_col {{membership_group.website_team_col_classes or 'col-lg-8'}}">
+                                <div class="card h-100 shadow-sm border-0">
+                                    <div class="card-header border-0 py-3 bg-primary text-white"
+                                         data-name="Team Header">
+                                        <h5 class="mb-0 fw-semibold">Team Members</h5>
+                                    </div>
+                                    <div class="card-body p-0">
+                                        <div>
+                                            <t t-set="team_members"
+                                               t-value="current_members.filtered(lambda m: m.type != 'committee').mapped('partner_id')"/>
+                                            <t t-call="website_membership_group.membership_group_member_list">
+                                                <t t-set="members" t-value="team_members"/>
+                                            </t>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-lg-8 col-md-8 mb48">
-                            <div class="col-lg-12">
-                                <h4>Team Members</h4>
-                            </div>
-                            <t t-set="team_members"
-                               t-value="current_members.filtered(lambda m:m.type != 'committee').mapped('partner_id')"/>
-                            <t t-if="team_members">
-                                <t t-call="website_membership_group.membership_group_member">
-                                    <t t-set="members" t-value="team_members"/>
-                                </t>
-                            </t>
-                            <h5 t-else="" class="col-lg-6">
-                                No Team Members found.
-                            </h5>
+                    </div>
+                </section>
+                <section class="mg_bottom_block pt-3">
+                    <div class="container">
+                        <div class="row">
+                            <div class="mt-3" t-field="membership_group.website_bottom"/>
                         </div>
                     </div>
-                </div>
-
+                </section>
                 <div class="oe_structure" id="oe_structure_website_membership_group_2"/>
             </div>
         </t>
     </template>
 
-    <template id="membership_group_member">
-        <div class="row">
-            <div class="col-lg-6" t-foreach="members"
-                 t-as="member">
-                <div class="o_web_membership_group_member mb-3 align-items-center d-flex">
-                    <img
-                            class="me-4 rounded-2 border border-secondary"
-                            t-att-src="image_data_uri(member.image_128 or member.avatar_128)"
-                            t-att-alt="member.name or ''"
-                            height="48" width="48"
-
-                    />
-                    <t t-if="member.website_published">
-                        <a t-attf-href="/members/#{slug(member)}">
-                            <span t-esc="member"
-                                  t-options='{"widget": "contact","fields": ["name"]}'/>
-                        </a>
-                    </t>
-                    <t t-else="">
-                        <span t-esc="member"
-                              t-options='{"widget": "contact","fields": ["name"]}'/>
+    <template id="membership_group_member_list">
+        <div class="mg_member_list d-flex flex-wrap">
+            <t t-foreach="members" t-as="member">
+                <div class="mg_member_item p-3 border-bottom-0">
+                    <div class="d-flex align-items-center gap-3">
+                        <img class="rounded-circle shadow-sm object-fit-cover"
+                             t-att-src="image_data_uri(member.image_128 or member.avatar_128)" t-att-alt="member.name"/>
+                        <div class="flex-grow-1 min-w-0 mg_member_name">
+                            <t t-if="member.website_published">
+                                <a t-attf-href="/members/#{slug(member)}" class="text-decoration-none">
+                                    <span class="fw-bold text-dark d-block text-wrap text-break lh-sm" t-esc="member.name"/>
+                                </a>
+                            </t>
+                            <t t-else="">
+                                <span class="fw-bold text-dark d-block text-wrap text-break lh-sm" t-esc="member.name"/>
+                            </t>
+                        </div>
+                        <button t-if="member.website_description"
+                                class="btn btn-sm text-muted text-decoration-none mg_collapse_btn"
+                                type="button"
+                                aria-expanded="false"
+                                t-att-aria-controls="'mg_desc_%s' % member.id">
+                            <i class="fa fa-chevron-down"></i>
+                        </button>
+                    </div>
+                    <t t-if="member.website_description">
+                        <div t-attf-class="mg_member_description overflow-hidden lh-base w-100 mt-2 pt-2 border-top small text-muted d-none"
+                             t-attf-id="mg_desc_{{member.id}}">
+                            <t t-esc="member.website_description"/>
+                        </div>
                     </t>
                 </div>
-            </div>
+            </t>
         </div>
     </template>
-
 </odoo>

--- a/website_membership_group/views/snippets/snippet_options.xml
+++ b/website_membership_group/views/snippets/snippet_options.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="membership_group_page_options" inherit_id="website.snippet_options">
+                <xpath expr="." position="inside">
+            <div data-js="MembershipGroupPage" data-selector="body:has(#mg_members_row) #wrap" data-page-options="true">
+                <we-title>Visibility</we-title>
+                <we-checkbox string="Show Group Image" data-select-class="mg_show_image"/>
+                <we-checkbox string="Show Top Content" data-select-class="mg_show_top"/>
+                <we-checkbox string="Show Bottom Content" data-select-class="mg_show_bottom"/>
+                <we-checkbox string="Show Committee" data-select-class="mg_show_committee"/>
+                <we-checkbox string="Show Team" data-select-class="mg_show_team"/>
+            </div>
+
+            <div data-js="MemberLayoutOpts" data-selector="#mg_members_row">
+                <we-title>Member Layout and Descriptions</we-title>
+
+                <we-button-group string="Layout">
+                    <we-button data-select-class="mg_layout_grid" data-name="mg_layout_grid" title="Grid">
+                        <i class="fa fa-th-list"/>
+                    </we-button>
+                    <we-button data-select-class="mg_layout_cards" data-name="mg_layout_cards" title="Cards">
+                        <i class="fa fa-th-large"/>
+                    </we-button>
+                    <we-button data-select-class="mg_layout_avatars" data-name="mg_layout_avatars" title="Avatars">
+                        <i class="fa fa-th"/>
+                    </we-button>
+                </we-button-group>
+                <we-checkbox string="Committee Description" data-select-class="mg_show_committee_desc" data-dependencies="mg_layout_cards,mg_layout_avatars"/>
+                <we-checkbox string="Team Description" data-select-class="mg_show_team_desc" data-dependencies="mg_layout_cards,mg_layout_avatars"/>
+                <we-checkbox string="Collapsible" data-select-class="mg_collapse_desc" data-dependencies="mg_layout_cards,mg_layout_avatars"/>
+            </div>
+            <div data-js="MemberColOpts" data-selector="body:has(#mg_members_row) .mg_team_col, .mg_committee_col"/>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
- [x] Analyze comment requesting filter of `mg_*` classes only before saving to DB
- [x] Fix `MembershipGroupPage._saveToDatabase` to only save `mg_*` classes to `website_snippet_wrap_classes`
- [x] Fix `MemberScrollOpts._saveToDatabase` to only save `mg_*` classes to `website_snippet_members_classes`
- [x] Added `hadPreviousClasses` guard to avoid unnecessary DB writes when classes become empty
- [x] Code review and security scan passed

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/onesteinbv/addons-generic/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
