### PR TITLE
[ADD] membership_activity_project_parent

### DIFF
--- a/membership_activity_project_parent/__init__.py
+++ b/membership_activity_project_parent/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/membership_activity_project_parent/__manifest__.py
+++ b/membership_activity_project_parent/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Membership Activity Project Parent",
+    "summary": "Adds parent project to membership activities",
+    "version": "18.0.1.0.0",
+    "category": "Project",
+    "license": "AGPL-3",
+    "author": "Onestein",
+    "website": "https://www.onestein.nl",
+    "depends": [
+        "membership_activity",
+        "project_parent",
+    ],
+    "data": [
+        "views/membership_activity_views.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+}

--- a/membership_activity_project_parent/models/__init__.py
+++ b/membership_activity_project_parent/models/__init__.py
@@ -1,0 +1,1 @@
+from . import membership_activity

--- a/membership_activity_project_parent/models/membership_activity.py
+++ b/membership_activity_project_parent/models/membership_activity.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class MembershipActivity(models.Model):
+    _inherit = "membership.activity"
+
+    parent_project_id = fields.Many2one(
+        comodel_name="project.project",
+        string="Parent Project",
+        related="project_id.parent_id",
+        store=True,
+        index=True,
+    )

--- a/membership_activity_project_parent/readme/DESCRIPTION.rst
+++ b/membership_activity_project_parent/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module adds a parent project field to membership activities.
+It makes it easy to group and categorize membership activities not just by their immediate project, but by the parent project as well.
+
+It extends the membership activity model when both `membership_activity` and `project_parent` are installed, providing views for grouping and filtering.

--- a/membership_activity_project_parent/views/membership_activity_views.xml
+++ b/membership_activity_project_parent/views/membership_activity_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_membership_activity_search_inherit_parent" model="ir.ui.view">
+        <field name="name">membership.activity.search.parent.project</field>
+        <field name="model">membership.activity</field>
+        <field name="inherit_id" ref="membership_activity.membership_activity_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='project_id']" position="after">
+                <field name="parent_project_id"/>
+            </xpath>
+            <xpath expr="//filter[@name='project_group_by']" position="after">
+                <filter name="group_by_parent_project"
+                        string="Parent Project"
+                        context="{'group_by': 'parent_project_id'}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_membership_activity_tree_inherit_parent" model="ir.ui.view">
+        <field name="name">membership.activity.tree.parent.project</field>
+        <field name="model">membership.activity</field>
+        <field name="inherit_id" ref="membership_activity.membership_activity_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='project_id']" position="after">
+                <field name="parent_project_id" optional="show"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR introduces a new module `membership_activity_project_parent`, which is automatically installed when both `project_parent` and `membership_activity` are present.

**Key Features:**

- Adds `parent_project_id` field to membership activities

- Extends the search view with:

     - Filter by parent project

     - Group by parent project

- Includes the field in the list view (optional show/hide)