### PR TITLE
[FIX] website_share_snapchat: remove conflicting click handler

### DIFF
--- a/website_share_snapchat/static/src/snippets/s_share/000.esm.js
+++ b/website_share_snapchat/static/src/snippets/s_share/000.esm.js
@@ -20,14 +20,6 @@ publicWidget.registry.share.include({
                         });
                     });
                 }
-
-                if ($a.attr('target') && $a.attr('target').match(/_blank/i) && !$a.closest('.o_editable').length) {
-                    $a.on('click', function () {
-                        // eslint-disable-next-line no-undef
-                        window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=550,width=600');
-                        return false;
-                    });
-                }
             });
         },
     });


### PR DESCRIPTION
## Issue
Sharing events (or any page) via social media buttons showed literal placeholders like {url} and {title}
 and  instead of the actual page URL and title.

## Root Cause
The snapchat module added a generic click handler to **all** share 
links with 'target='_blank_. This handler opened the raw, unmodified href in a 
popup, bypassing Odoo's base ShareWidget which correctly replaces {url}  and 
'{title}' placeholders on click.

## Fix
Remove the redundant generic click handler from the snapchat module, keeping only 
the Snapchat-specific URL preprocessing (replacing 'attachmentUrl').

## Testing
Verified on a local CURQ 18.0 instance that Facebook, Twitter/X, LinkedIn, 
WhatsApp, Telegram, and Reddit now all share the correct URL and title.