### PR TITLE
[IMP] website_membership_group: integrate Members dynamic snippet

### DIFF
--- a/website_membership_group/__manifest__.py
+++ b/website_membership_group/__manifest__.py
@@ -13,17 +13,22 @@
         "website_membership",
     ],
     "data": [
+        "data/website_snippet_filter_data.xml",
         "views/membership_group_view.xml",
         "templates/website.xml",
         "views/snippets/snippet_options.xml",
+        "views/snippets/dynamic_templates.xml",
+        "views/snippets/members_snippet.xml",
     ],
     "assets": {
         "web.assets_frontend": [
             "website_membership_group/static/src/scss/membership_group.scss",
             "website_membership_group/static/src/js/membership_group_frontend.esm.js",
+            "website_membership_group/static/src/js/membership_snippet.esm.js",
         ],
         "website.assets_wysiwyg": [
             "website_membership_group/static/src/js/membership_group_options.esm.js",
+            "website_membership_group/static/src/js/membership_snippet_options.esm.js",
         ],
     },
 }

--- a/website_membership_group/controllers/main.py
+++ b/website_membership_group/controllers/main.py
@@ -35,3 +35,17 @@ class MembershipGroupController(http.Controller):
         vals = self._membership_group_page_render_vals(membership_group_sudo)
 
         return request.render("website_membership_group.membership_group_page", vals)
+
+    @http.route("/membership/snippet/groups", type="json", auth="public", website=True)
+    def snippet_groups(self):
+        groups = (
+            request.env["membership.group"]
+            .sudo()
+            .search(
+                [
+                    ("is_published", "=", True),
+                ],
+                order="name",
+            )
+        )
+        return [{"id": g.id, "name": g.name} for g in groups]

--- a/website_membership_group/data/website_snippet_filter_data.xml
+++ b/website_membership_group/data/website_snippet_filter_data.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Filter for Dynamic Snippet -->
+        <record id="dynamic_snippet_membership_members_filter" model="ir.filters">
+            <field name="name">Membership Members</field>
+            <field name="model_id">res.partner</field>
+            <field name="user_id" eval="False"/>
+            <field name="domain">[('website_published', '=', True), ('membership_group_member_ids.state', '=', 'current')]</field>
+            <field name="sort">["name asc"]</field>
+            <field name="action_id" ref="website.action_website"/>
+        </record>
+
+        <!-- Dynamic Filter -->
+        <record id="dynamic_filter_membership_members" model="website.snippet.filter">
+            <field name="name">Membership Members</field>
+            <field name="filter_id" ref="website_membership_group.dynamic_snippet_membership_members_filter"/>
+            <field name="field_names">name,image_128,website_description</field>
+            <field name="limit" eval="16"/>
+        </record>
+    </data>
+</odoo>

--- a/website_membership_group/models/__init__.py
+++ b/website_membership_group/models/__init__.py
@@ -1,1 +1,2 @@
 from . import membership_group
+from . import website_snippet_filter

--- a/website_membership_group/models/website_snippet_filter.py
+++ b/website_membership_group/models/website_snippet_filter.py
@@ -1,0 +1,71 @@
+from odoo import fields, models
+
+
+class WebsiteSnippetFilter(models.Model):
+    _inherit = "website.snippet.filter"
+
+    def _filter_records_to_values(self, records, is_sample=False):
+        meta_data = self._get_filter_meta_data()
+        values = []
+        model = self.env[self.model_name]
+        Website = self.env["website"]
+        for record in records:
+            data = {}
+            for field_name, field_widget in meta_data.items():
+                field = model._fields.get(field_name)
+                if field and field.type in ("binary", "image"):
+                    if is_sample:
+                        raw = record[field_name]
+                        if field_name in record and raw and raw is not True and raw is not False:
+                            data[field_name] = raw.decode("utf8")
+                        else:
+                            data[field_name] = "/web/image"
+                    else:
+                        data[field_name] = Website.image_url(record, field_name)
+                elif field_widget == "monetary":
+                    model_currency = None
+                    if field and field.type == "monetary":
+                        model_currency = record[field.get_currency_field(record)]
+                    elif "currency_id" in model._fields:
+                        model_currency = record["currency_id"]
+                    if model_currency:
+                        website_currency = self._get_website_currency()
+                        data[field_name] = model_currency._convert(
+                            record[field_name],
+                            website_currency,
+                            Website.get_current_website().company_id,
+                            fields.Date.today(),
+                        )
+                    else:
+                        data[field_name] = record[field_name]
+                else:
+                    data[field_name] = record[field_name]
+            data["call_to_action_url"] = False
+            if not is_sample:
+                data["call_to_action_url"] = (
+                    "website_url" in record and record["website_url"]
+                )
+            data["_record"] = record
+            values.append(data)
+        return values
+
+    def _render(self, template_key, limit, search_domain=None, with_sample=False, **custom_template_data):
+        if with_sample and search_domain:
+            records = self._prepare_values(limit=1, search_domain=search_domain)
+            if not records:
+                with_sample = False
+
+        fragments = super()._render(
+            template_key, limit,
+            search_domain=search_domain,
+            with_sample=with_sample,
+            **custom_template_data,
+        )
+        if not fragments:
+            return [
+                '<div class="text-center text-muted py-4 w-100">'
+                '<p class="mb-0">No members found.</p>'
+                '<small>Make sure members are published and have an active membership in the selected group.</small>'
+                '</div>'
+            ]
+        return fragments

--- a/website_membership_group/static/src/js/membership_snippet.esm.js
+++ b/website_membership_group/static/src/js/membership_snippet.esm.js
@@ -1,0 +1,40 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+import DynamicSnippet from "@website/snippets/s_dynamic_snippet/000";
+
+const DynamicSnippetMembers = DynamicSnippet.extend({
+    selector: ".s_dynamic_snippet_members",
+    disabledInEditableMode: false,
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     * @private
+     */
+    _getSearchDomain: function () {
+        const searchDomain = this._super.apply(this, arguments);
+        const filterByGroupId = parseInt(this.$el.get(0).dataset.filterByGroupId);
+        if (filterByGroupId >= 0) {
+            searchDomain.push(
+                ["membership_group_member_ids.group_id", "=", filterByGroupId],
+                ["membership_group_member_ids.state", "=", "current"]
+            );
+        }
+        return searchDomain;
+    },
+    /**
+     * @override
+     * @private
+     */
+    _getMainPageUrl() {
+        return "/members";
+    },
+});
+
+publicWidget.registry.dynamic_snippet_members = DynamicSnippetMembers;
+
+export default DynamicSnippetMembers;

--- a/website_membership_group/static/src/js/membership_snippet_options.esm.js
+++ b/website_membership_group/static/src/js/membership_snippet_options.esm.js
@@ -1,0 +1,73 @@
+/** @odoo-module **/
+
+import options from "@web_editor/js/editor/snippets.options";
+import dynamicSnippetOptions from "@website/snippets/s_dynamic_snippet/options";
+import { rpc } from "@web/core/network/rpc";
+
+const dynamicSnippetMembersOptions = dynamicSnippetOptions.extend({
+    /**
+     * @override
+     */
+    init: function () {
+        this._super.apply(this, arguments);
+        this.modelNameFilter = "res.partner";
+        this.groups = {};
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     * @private
+     */
+    _computeWidgetVisibility: function (widgetName, params) {
+        return this._super.apply(this, arguments);
+    },
+    /**
+     * Fetches published membership groups.
+     * @private
+     * @returns {Promise}
+     */
+    _fetchGroups: function () {
+        return rpc("/membership/snippet/groups");
+    },
+    /**
+     * @override
+     * @private
+     */
+    _renderCustomXML: async function (uiFragment) {
+        await this._super.apply(this, arguments);
+        await this._renderGroupSelector(uiFragment);
+    },
+    /**
+     * Renders the group option selector content into the provided uiFragment.
+     * @private
+     * @param {HTMLElement} uiFragment
+     */
+    _renderGroupSelector: async function (uiFragment) {
+        if (!Object.keys(this.groups).length) {
+            const groupsList = await this._fetchGroups();
+            this.groups = {};
+            for (let index in groupsList) {
+                this.groups[groupsList[index].id] = groupsList[index];
+            }
+        }
+        const groupSelectorEl = uiFragment.querySelector('[data-name="group_opt"]');
+        return this._renderSelectUserValueWidgetButtons(groupSelectorEl, this.groups);
+    },
+    /**
+     * Sets default options values.
+     * @override
+     * @private
+     */
+    _setOptionsDefaultValues: function () {
+        this._setOptionValue("filterByGroupId", -1);
+        this._super.apply(this, arguments);
+    },
+});
+
+options.registry.dynamic_snippet_members = dynamicSnippetMembersOptions;
+
+export default dynamicSnippetMembersOptions;

--- a/website_membership_group/tests/__init__.py
+++ b/website_membership_group/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_membership_snippet

--- a/website_membership_group/tests/test_membership_snippet.py
+++ b/website_membership_group/tests/test_membership_snippet.py
@@ -1,0 +1,103 @@
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestMembershipSnippet(HttpCase):
+    """Tests for the membership members dynamic snippet."""
+
+    def test_snippet_filter_exists(self):
+        """The dynamic snippet filter record exists."""
+        filter_record = self.env.ref(
+            "website_membership_group.dynamic_filter_membership_members",
+            raise_if_not_found=False,
+        )
+        self.assertTrue(filter_record)
+        self.assertEqual(filter_record.model_name, "res.partner")
+        self.assertEqual(filter_record.limit, 16)
+
+    def test_snippet_groups_endpoint(self):
+        """The /membership/snippet/groups endpoint returns published groups."""
+        self.env["membership.group"].create(
+            {
+                "name": "Test Group",
+                "is_published": True,
+            }
+        )
+        result = self.url_open(
+            "/membership/snippet/groups",
+            data='{"jsonrpc": "2.0", "method": "call", "params": {}, "id": 1}',
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(result.status_code, 200)
+        data = result.json()
+        self.assertIn("result", data)
+        group_names = [g["name"] for g in data["result"]]
+        self.assertIn("Test Group", group_names)
+
+    def test_dynamic_filter_renders_members(self):
+        """The dynamic filter renders members for a published group."""
+        group = self.env["membership.group"].create(
+            {
+                "name": "Dynamic Test Group",
+                "is_published": True,
+            }
+        )
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Dynamic Test Member",
+                "website_published": True,
+            }
+        )
+        self.env["membership.group.member"].create(
+            {
+                "group_id": group.id,
+                "partner_id": partner.id,
+                "type": "committee",
+                "state": "current",
+            }
+        )
+
+        filter_record = self.env.ref(
+            "website_membership_group.dynamic_filter_membership_members"
+        )
+        fragments = filter_record._render(
+            "website_membership_group.dynamic_filter_template_res_partner_grid",
+            limit=16,
+            search_domain=[("membership_group_member_ids.group_id", "=", group.id)],
+        )
+        self.assertTrue(fragments)
+        self.assertIn("Dynamic Test Member", fragments[0])
+
+    def test_dynamic_filter_hides_unpublished_members(self):
+        """Unpublished partners are not rendered."""
+        group = self.env["membership.group"].create(
+            {
+                "name": "Hidden Member Group",
+                "is_published": True,
+            }
+        )
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Hidden Member",
+                "website_published": False,
+            }
+        )
+        self.env["membership.group.member"].create(
+            {
+                "group_id": group.id,
+                "partner_id": partner.id,
+                "type": "committee",
+                "state": "current",
+            }
+        )
+
+        filter_record = self.env.ref(
+            "website_membership_group.dynamic_filter_membership_members"
+        )
+        fragments = filter_record._render(
+            "website_membership_group.dynamic_filter_template_res_partner_grid",
+            limit=16,
+            search_domain=[("membership_group_member_ids.group_id", "=", group.id)],
+        )
+        # Should be empty because partner is not website_published
+        self.assertFalse(any("Hidden Member" in f for f in fragments))

--- a/website_membership_group/views/snippets/dynamic_templates.xml
+++ b/website_membership_group/views/snippets/dynamic_templates.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Grid Layout -->
+    <template id="dynamic_filter_template_res_partner_grid" name="Grid">
+        <div t-foreach="records" t-as="data" class="s_membership_members_item w-100"
+             data-extra-classes="g-3" data-column-classes="col-md-4 col-lg-3">
+            <t t-set="record" t-value="data['_record']"/>
+            <div class="card h-100 shadow-sm">
+                <div class="card-body text-center">
+                    <img class="rounded-circle mb-3"
+                         style="width: 80px; height: 80px; object-fit: cover;"
+                         t-att-src="data['image_128'] or '/web/static/img/user_placeholder.jpg'"
+                         t-att-alt="data['name']"/>
+                    <h5 class="card-title" t-field="record.name"/>
+                    <p t-if="data['website_description']" class="card-text text-muted small"
+                       t-field="record.website_description"/>
+                    <a t-if="data['call_to_action_url']" t-att-href="data['call_to_action_url']"
+                       class="btn btn-sm btn-primary">View Profile</a>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <!-- List Layout -->
+    <template id="dynamic_filter_template_res_partner_list" name="List">
+        <div t-foreach="records" t-as="data" class="s_membership_members_item w-100"
+             data-extra-classes="g-3" data-column-classes="col-12">
+            <t t-set="record" t-value="data['_record']"/>
+            <div class="d-flex align-items-center gap-3 p-3 bg-light rounded">
+                <img class="rounded-circle"
+                     style="width: 60px; height: 60px; object-fit: cover;"
+                     t-att-src="data['image_128'] or '/web/static/img/user_placeholder.jpg'"
+                     t-att-alt="data['name']"/>
+                <div class="flex-grow-1">
+                    <h6 class="mb-0" t-field="record.name"/>
+                    <small t-if="data['website_description']" class="text-muted"
+                           t-field="record.website_description"/>
+                </div>
+                <a t-if="data['call_to_action_url']" t-att-href="data['call_to_action_url']"
+                   class="btn btn-sm btn-outline-primary">View</a>
+            </div>
+        </div>
+    </template>
+
+    <!-- Avatars Layout -->
+    <template id="dynamic_filter_template_res_partner_avatars" name="Avatars">
+        <div t-foreach="records" t-as="data" class="s_membership_members_item w-100"
+             data-extra-classes="g-3" data-column-classes="col-6 col-md-3 col-lg-2">
+            <t t-set="record" t-value="data['_record']"/>
+            <div class="text-center p-2">
+                <img class="rounded-circle mb-2"
+                     style="width: 50px; height: 50px; object-fit: cover;"
+                     t-att-src="data['image_128'] or '/web/static/img/user_placeholder.jpg'"
+                     t-att-alt="data['name']"/>
+                <p class="small mb-0" t-field="record.name"/>
+            </div>
+        </div>
+    </template>
+</odoo>

--- a/website_membership_group/views/snippets/members_snippet.xml
+++ b/website_membership_group/views/snippets/members_snippet.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Snippet -->
+    <template id="s_membership_members" name="Members">
+        <t t-call="website.s_dynamic_snippet_template">
+            <t t-set="snippet_name" t-value="'s_membership_members'"/>
+            <t t-set="snippet_classes" t-value="'s_dynamic_snippet_members'"/>
+            <t t-set="custom_template_data" t-value="'{}'"/>
+        </t>
+    </template>
+
+    <!-- Register Snippet in Panel -->
+    <template id="snippets" inherit_id="website.snippets">
+        <xpath expr="//t[@id='installed_snippets_hook']" position="after">
+            <t t-snippet="website_membership_group.s_membership_members"
+               string="Members"
+               t-thumbnail="/website/static/src/img/snippets_thumbs/s_company_team.svg"/>
+        </xpath>
+    </template>
+
+    <!-- Options -->
+    <template id="s_membership_members_options" inherit_id="website.snippet_options">
+        <xpath expr="." position="inside">
+            <t t-call="website.s_dynamic_snippet_options_template">
+                <t t-set="snippet_name" t-value="'dynamic_snippet_members'"/>
+                <t t-set="snippet_selector" t-value="'.s_dynamic_snippet_members'"/>
+            </t>
+        </xpath>
+    </template>
+
+    <!-- Extra options for membership group selector -->
+    <template id="s_dynamic_snippet_members_options_template" inherit_id="website.s_dynamic_snippet_options_template">
+        <xpath expr="//we-select[@data-name='template_opt']" position="after">
+            <we-select t-if="snippet_name == 'dynamic_snippet_members'"
+                string="Membership Group"
+                data-no-preview="true"
+                data-name="group_opt"
+                data-attribute-name="filterByGroupId">
+                <we-button data-select-data-attribute="-1">All groups</we-button>
+                <!-- group list generated in JS -->
+            </we-select>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
> **Note:** This pull request was planned using DeepSeek V4 Pro and executed using DeepSeek V4 Flash with Opencode.

## Summary
- Merges the `website_membership_snippet` module into `website_membership_group`
- The "Members" dynamic snippet can now be dragged onto any website page
- Users can filter by membership group via the snippet options panel
- Three layout variants: Grid, List, Avatars

## Key details
- New controller endpoint `/membership/snippet/groups` returns published groups as JSON
- Dynamic snippet frontend extends Odoo's `DynamicSnippet` with group + state filtering
- Snippet options include a "Membership Group" `<we-select>` dropdown, populated via RPC
- Fixes an Odoo core crash when `_filter_records_to_values` encounters `False` on binary/image fields for sample records
- Shows a "No members found" message in the editor when a group has no published/current members
- Removed `test_snippet_templates_exist` (duplicative check)
- Filters out unpublished members (respects `website_published` flag)

## Files changed
| Action | File |
|--------|------|
| **CREATE** | `data/website_snippet_filter_data.xml` |
| **CREATE** | `views/snippets/dynamic_templates.xml` |
| **CREATE** | `views/snippets/members_snippet.xml` |
| **CREATE** | `static/src/js/membership_snippet.esm.js` |
| **CREATE** | `static/src/js/membership_snippet_options.esm.js` |
| **CREATE** | `models/website_snippet_filter.py` |
| **CREATE** | `tests/test_membership_snippet.py` |
| **MODIFY** | `__manifest__.py` |
| **MODIFY** | `controllers/main.py` |
| **MODIFY** | `models/__init__.py` |
| **REMOVE** | `website_membership_snippet/` (entire module) |
